### PR TITLE
Remove interface for cross-compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ artifacts/*
 apidocs/docbox/*
 workbench/*
 build/*
+
+# Engines
+.engine/**

--- a/.module.properties
+++ b/.module.properties
@@ -1,3 +1,3 @@
 project.name=cbjavaloader
-project.version=1.6.0
+project.version=1.7.0
 module.name=cbjavaloader

--- a/.module.properties
+++ b/.module.properties
@@ -1,3 +1,3 @@
 project.name=cbjavaloader
-project.version=1.4.0
+project.version=1.5.0
 module.name=cbjavaloader

--- a/.module.properties
+++ b/.module.properties
@@ -1,3 +1,3 @@
 project.name=cbjavaloader
-project.version=1.5.0
+project.version=1.6.0
 module.name=cbjavaloader

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   matrix:
     - ENGINE=lucee@4.5
     - ENGINE=lucee@5
-    - ENGINE=adobe@10
     - ENGINE=adobe@11
     - ENGINE=adobe@2016
 
@@ -32,8 +31,6 @@ before_install:
 install:
   # Install Commandbox
   - sudo apt-get update && sudo apt-get --assume-yes install rsync jq commandbox
-  # Test that the box binary is available and ready for our tests
-  - box version
   # If using auto-publish, you will need to provide your API token with this line:
   - box config set endpoints.forgebox.APIToken=$FORGEBOX_API_TOKEN > /dev/null
   # Setup for our tests

--- a/apidocs/box.json
+++ b/apidocs/box.json
@@ -4,11 +4,9 @@
     "slug":"module-apidocs",
     "private":true,
     "dependencies":{
-        "docbox":"^2.0.7+00005"
+        "docbox":"^2.2.1+27"
     },
-    "devDependencies":{
-        
-    },
+    "devDependencies":{},
     "installPaths":{
         "docbox":"docbox"
     }

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbjavaloader Builder",
-    "version":"1.6.0",
+    "version":"1.7.0",
     "slug":"cbjavaloader-shell",
     "private":false,
     "defaultPort":0,

--- a/box.json
+++ b/box.json
@@ -1,20 +1,20 @@
 {
     "name":"cbjavaloader Builder",
-    "version":"1.4.0",
+    "version":"1.5.0",
     "slug":"cbjavaloader-shell",
     "private":false,
     "defaultPort":0,
     "dependencies":{
-        "coldbox":"^4.3.0",
-        "workbench":"git+https://github.com/Ortus-Solutions/unified-workbench.git"
+        "workbench":"git+https://github.com/Ortus-Solutions/unified-workbench.git",
+        "coldbox":"^4.3.0+188"
     },
     "devDependencies":{
-        "testbox":"^2.4.0+80"
+        "testbox":"^2.6.0+156"
     },
     "installPaths":{
-        "coldbox":"coldbox",
         "testbox":"testbox",
-        "workbench":"workbench"
+        "workbench":"workbench",
+        "coldbox":"/Users/lmajano/Sites/cboxdev/coldbox-core-modules/cbox-javaloader/coldbox"
     },
     "testbox":{
         "runner":"http://localhost:49616"

--- a/box.json
+++ b/box.json
@@ -12,9 +12,9 @@
         "testbox":"^2.6.0+156"
     },
     "installPaths":{
-        "testbox":"testbox",
-        "workbench":"workbench",
-        "coldbox":"/Users/lmajano/Sites/cboxdev/coldbox-core-modules/cbox-javaloader/coldbox"
+        "workbench":"workbench/",
+        "coldbox":"coldbox/",
+        "testbox":"testbox/"
     },
     "testbox":{
         "runner":"http://localhost:49616"

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name":"cbjavaloader Builder",
-    "version":"1.5.0",
+    "version":"1.6.0",
     "slug":"cbjavaloader-shell",
     "private":false,
     "defaultPort":0,

--- a/changelog.md
+++ b/changelog.md
@@ -1,33 +1,46 @@
-CHANGELOG
-=========
+# CHANGELOG
+
+## 1.5.0
+
+* Updated interfaces for Coldbox 5 support
+* More local testing updates
+* Updated dependencies
+* Dropped cf10 support
 
 ## 1.4.0
+
 * Updated internal core Javaloader library to latest 1.2 release
 * Added automatic dynamic proxy class loading
 * Deprecating support for cf10
 
 ## 1.3.3
+
 * Cleanup of testing Application.cfc
 
 ## 1.3.2
+
 * Removal of security issues with Javaloader `tags` directory
 * Securing execution of Javaloader models
 * Updated to unified workbench
 
 ## 1.3.1
+
 * Travis Update Builds
 * Adobe CF 2016,11,10 compatiblity fixes
 
 ## 1.3.0
+
 * Adobe CF Compatiblity
 
 ## 1.2.0
+
 * Travis Updates	
 * Changing the array of locations check so that it doesn't fail if a JAR file is passed in the array.
 * Readme Updates
 * ForgeBox2 Updates
 
 ## 1.1.0
+
 * Travis Integration
 * DocBox update
 * Build updates
@@ -36,4 +49,5 @@ CHANGELOG
 * Better documentation
 
 ## 1.0.0
+
 * Create first module version

--- a/modules/cbjavaloader/models/JavaLoaderDSL.cfc
+++ b/modules/cbjavaloader/models/JavaLoaderDSL.cfc
@@ -4,7 +4,7 @@
 * ---
 * The JavaLoader WireBox DSL
 */
-component implements="coldbox.system.ioc.dsl.IDSLBuilder" accessors="true"{
+component accessors="true"{
 
 	/**
 	* WireBox Injector
@@ -20,7 +20,7 @@ component implements="coldbox.system.ioc.dsl.IDSLBuilder" accessors="true"{
 	/**
 	* Constructor as per interface
 	*/
-	public any function init( required any injector ) output="false"{
+	public any function init( required any injector ){
 		variables.injector 	= arguments.injector;
 		variables.log		= arguments.injector.getLogBox().getLogger( this );
 
@@ -30,7 +30,7 @@ component implements="coldbox.system.ioc.dsl.IDSLBuilder" accessors="true"{
 	/**
 	* Process an incoming DSL definition and produce an object with it.
 	*/
-	public any function process( required definition, targetObject ) output="false"{
+	public any function process( required definition, targetObject ){
 		var DSLNamespace = listFirst( arguments.definition.dsl, ":" );
 		switch( DSLNamespace ){
 			case "javaloader" : { return getJavaLoaderDSL( argumentCollection=arguments );}

--- a/readme.md
+++ b/readme.md
@@ -5,15 +5,18 @@
 The CB JavaLoader module will interface with Mark Mandel's JavaLoader to allow you to do a network class loader, compiler and proxy.  
 
 ## License
+
 Apache License, Version 2.0.
 
 ## Important Links
+
 - https://github.com/coldbox-modules/cbox-javaloader
 - https://forgebox.io/view/javaloader
 - Docs: https://github.com/Ortus-Solutions/JavaLoader
 - [Changelog](changelog.md)
 
 ## System Requirements
+
 - Lucee 4.5+
 - ColdFusion 11+
 
@@ -94,7 +97,8 @@ component{
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 www.ortussolutions.com
 ********************************************************************************
-####HONOR GOES TO GOD ABOVE ALL
+
+#### HONOR GOES TO GOD ABOVE ALL
 Because of His grace, this project exists. If you don't like this, then don't read it, its not for you.
 
 >"Therefore being justified by faith, we have peace with God through our Lord Jesus Christ:
@@ -104,5 +108,5 @@ And patience, experience; and experience, hope:
 And hope maketh not ashamed; because the love of God is shed abroad in our hearts by the 
 Holy Ghost which is given unto us. ." Romans 5:5
 
-###THE DAILY BREAD
+### THE DAILY BREAD
  > "I am the way, and the truth, and the life; no one comes to the Father, but by me (JESUS)" Jn 14:1-12

--- a/server.json
+++ b/server.json
@@ -5,5 +5,9 @@
         "http":{
             "port":"49616"
         }
+    },
+    "app":{
+        "cfengine":"lucee@4.5",
+        "serverHomeDirectory":".engine/lucee4"
     }
 }

--- a/tests/specs/LoaderTest.cfc
+++ b/tests/specs/LoaderTest.cfc
@@ -42,7 +42,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root"{
 			it( "should get loaded URLs", function(){
 				var loader = getLoader();
 				expect(	loader.getLoadedURls() ).toBeArray();
-				expect( loader.getLoadedURLs() ).toHaveLength( 1 );
+				expect( loader.getLoadedURLs() ).toHaveLength( 2 );
 			});
 
 			it( "should retrieve via custom DSL", function(){


### PR DESCRIPTION
The interface currently implemented is not cross-compatible between Coldbox 4 and 5.  The only way to ensure dependencies are stable between the two versions is to remove the interface implementation