### PR TITLE
path changed to dirPath to match argument name

### DIFF
--- a/modules/cbjavaloader/models/Loader.cfc
+++ b/modules/cbjavaloader/models/Loader.cfc
@@ -133,7 +133,7 @@ component accessors="true" singleton{
 	*/
 	array function arrayOfJars( required string dirPath, string filter="*.jar" ){
 		if( not directoryExists( arguments.dirPath ) ){
-			throw( message="Invalid library path", detail="The path is #path#", type="JavaLoader.DirectoryNotFoundException" );
+			throw( message="Invalid library path", detail="The path is #dirPath#", type="JavaLoader.DirectoryNotFoundException" );
 		}
 
 		return directoryList( arguments.dirPath, true, "array", arguments.filter, "name desc" );


### PR DESCRIPTION
This was throwing an error when an invalid path was supplied. The throw message was then throwing an error indicating that variables.path was not defined.