### PR TITLE
Boxlang compat

### DIFF
--- a/models/javaloader/JavaLoader.cfc
+++ b/models/javaloader/JavaLoader.cfc
@@ -116,7 +116,7 @@
 		try {
 			if ( server.keyExists( "boxlang" ) ) {
 				// Boxlang's Dynamic object class handles all of our needs - we just need to retrieve the class through the module classloader
-				return createObject( "java", "ortus.boxlang.runtime.interop.DynamicObject" ).init(
+				return createObject( "java", "ortus.boxlang.runtime.interop.DynamicObject" ).of(
 					getURLClassLoader().loadClass( arguments.className )
 				);
 			} else {


### PR DESCRIPTION
# Description

Lucee and ACF both have a `coldfusion.runtime.java.JavaProxy` that their engines know how to deal with.  When that class can't be found, it falls back to using a JavaProxy CFC class - which causes all sorts of interop issues.   The solution is to return the BoxLang dynamic object class, with the class itself retrieved via the module classloader.

## Type of change

- [X] Improvement

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
